### PR TITLE
ClojureScript support

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,10 +1,13 @@
 (defproject pathetic "0.5.0-SNAPSHOT"
   :description "The missing path handling."
-  :dependencies [[org.clojure/clojure "1.5.1"]]
+  :dependencies [[org.clojure/clojure "1.5.1"]
+                 [com.cemerick/clojurescript.test "0.0.4"]]
 
   :source-paths ["generated-src"]
-  :plugins [[com.keminglabs/cljx "0.2.2"]]
-  :hooks [cljx.hooks]
+  :test-paths ["generated-test"]
+  :plugins [[com.keminglabs/cljx "0.2.2"]
+            [lein-cljsbuild "0.3.2"]]
+;;  :hooks [cljx.hooks leiningen.cljsbuild] disabled due to a bug in cljx
   :cljx {:builds [{:source-paths ["src"]
                    :output-path "generated-src"
                    :rules cljx.rules/clj-rules}
@@ -12,5 +15,19 @@
                   {:source-paths ["src"]
                    :output-path "generated-src"
                    :extension "cljs"
+                   :rules cljx.rules/cljs-rules}
+
+                  {:source-paths ["test"]
+                   :output-path "generated-test"
+                   :rules cljx.rules/clj-rules}
+
+                  {:source-paths ["test"]
+                   :output-path "generated-test"
+                   :extension "cljs"
                    :rules cljx.rules/cljs-rules}]}
+  :cljsbuild {:builds [{:source-paths ["generated-src" "generated-test"]
+                        :compiler {:output-to "target/cljs/testable.js"
+                        :optimizations :whitespace
+                        :pretty-print true}}]
+              :test-commands {"unit-tests" ["runners/phantomjs.js" "target/cljs/testable.js"]}}
   :profiles {:clojure1.3 {:dependencies [[org.clojure/clojure "1.3.0"]]}})

--- a/project.clj
+++ b/project.clj
@@ -1,5 +1,16 @@
-(defproject pathetic "0.4.0"
+(defproject pathetic "0.5.0-SNAPSHOT"
   :description "The missing path handling."
-  :dependencies [[org.clojure/clojure "1.2.1"]]
+  :dependencies [[org.clojure/clojure "1.5.1"]]
 
+  :source-paths ["generated-src"]
+  :plugins [[com.keminglabs/cljx "0.2.2"]]
+  :hooks [cljx.hooks]
+  :cljx {:builds [{:source-paths ["src"]
+                   :output-path "generated-src"
+                   :rules cljx.rules/clj-rules}
+
+                  {:source-paths ["src"]
+                   :output-path "generated-src"
+                   :extension "cljs"
+                   :rules cljx.rules/cljs-rules}]}
   :profiles {:clojure1.3 {:dependencies [[org.clojure/clojure "1.3.0"]]}})

--- a/runners/phantomjs.js
+++ b/runners/phantomjs.js
@@ -1,0 +1,29 @@
+#!/usr/bin/env phantomjs
+
+// reusable phantomjs script for running clojurescript.test tests
+// see http://github.com/cemerick/clojurescript.test for more info
+
+var p = require('webpage').create();
+var sys = require('system');
+p.injectJs(sys.args[1]);
+
+p.onConsoleMessage = function (x) {
+  var line = x;
+  if (line !== "[NEWLINE]") {
+    console.log(line.replace(/\[NEWLINE\]/g, "\n"));
+  }
+};
+
+p.evaluate(function () {
+  cemerick.cljs.test.set_print_fn_BANG_(function(x) {
+    console.log(x.replace(/\n/g, "[NEWLINE]")); // since console.log *itself* adds a newline
+  });
+});
+
+var success = p.evaluate(function () {
+  var results = cemerick.cljs.test.run_all_tests();
+  console.log(results);
+  return cemerick.cljs.test.successful_QMARK_(results);
+});
+
+phantom.exit(success ? 0 : 1);

--- a/src/pathetic/core.cljx
+++ b/src/pathetic/core.cljx
@@ -88,10 +88,18 @@
 ;; Core Functions
 ;;
 
+(defn ^:clj starts-with
+  [^String s ^String prefix]
+  (.startsWith s prefix))
+
+(defn ^:cljs starts-with
+  [s prefix]
+  (goog.string.startsWith s prefix))
+
 (defn absolute-path?
   "Returns true if the given argument is an absolute path."
   [path]
-  (.startsWith path separator))
+  (starts-with path separator))
 
 (defn up-dir
   "Given a seq of path elements as created by parse-path, returns a new
@@ -204,7 +212,7 @@
                          (parse-path other-path))))
 
 (defn ^:clj ends-with
-  [^String s suffix]
+  [^String s ^String suffix]
   (.endsWith s suffix))
 
 (defn ^:cljs ends-with

--- a/src/pathetic/core.cljx
+++ b/src/pathetic/core.cljx
@@ -39,6 +39,16 @@
   (let [common-parts (common-prefix uninteresting-coll interesting-coll)]
     (drop (count common-parts) interesting-coll)))
 
+(defn ^:clj split
+  [path]
+  (str/split (str path) separator-pattern))
+
+(defn ^:cljs split
+  [path]
+  (if (= path separator)
+    []
+    (str/split (str path) separator-pattern)))
+
 (defn parse-path
   "Given a j.io.File or string containing a relative or absolute path,
    returns the corresponding path vector data structure described at
@@ -53,7 +63,7 @@
   ;; indistinguishable. This avoids having an empty path parsed into [:root].
   (if (empty? (str path))
     nil
-    (let [path-pieces (str/split (str path) separator-pattern)]
+    (let [path-pieces (split path)]
       ;; (str/split "/" #"/") => [], so we check for this case first.
       (if (= 0 (count path-pieces))
         [:root]

--- a/src/pathetic/core.cljx
+++ b/src/pathetic/core.cljx
@@ -5,6 +5,7 @@
 ^:cljs (ns pathetic.core
          (:refer-clojure :exclude [resolve])
          (:require [clojure.string :as str]
+                   [goog.Uri :as uri]
                    [goog.string :as string]))
 
 (def ^{:private true} separator "/")
@@ -231,15 +232,25 @@
 ;; URL Utilities
 ;;
 
+(defn ^:clj as-url
+  [url-or-string]
+  (if (instance? java.net.URL url-or-string)
+    url-or-string
+    (java.net.URL. url-or-string)))
+
+(defn ^:cljs as-url
+  [url-or-string]
+  (if (instance? goog.Uri url-or-string)
+    url-or-string
+    (goog.Uri. url-or-string)))
+
 (defn split-url-on-path
   "Given a URL or string containing a URL, returns a vector of the three
    component strings: the stuff before the path, the path, and the stuff
    after the path. Useful for destructuring."
   [url-or-string]
-  ;; We borrow j.n.URL's parser just to make sure we get the right path.
-  (let [url (if (instance? java.net.URL url-or-string)
-              url-or-string
-              (java.net.URL. url-or-string))
+  ;; We borrow j.n.URL's or goog.Uri's parser just to make sure we get the right path.
+  (let [url (as-url url-or-string)
         url-string (str url)
         path (.getPath url)
         path-idx (.lastIndexOf url-string path)

--- a/src/pathetic/core.cljx
+++ b/src/pathetic/core.cljx
@@ -129,6 +129,15 @@
   [path]
   (render-path (normalize* (parse-path path))))
 
+(defn ^:clj throw-no-common-components
+  []
+  (throw (IllegalArgumentException.
+           "Paths contain no common components.")))
+
+(defn ^:cljs throw-no-common-components
+  []
+  (throw "Paths contain no common components."))
+
 (defn relativize*
   "Takes two absolute paths or two relative paths, and returns a relative path
    that indicates the same file system location as dest-path, but
@@ -139,8 +148,7 @@
         base-suffix (drop (count common-path) base-path)
         dest-suffix (drop (count common-path) dest-path)]
     (if (nil? common-path)
-      (throw (IllegalArgumentException.
-              "Paths contain no common components.")))
+      (throw-no-common-components))
     (concat [:cwd]
             (repeat (count base-suffix) "..")
             (loop [suffix []

--- a/src/pathetic/core.cljx
+++ b/src/pathetic/core.cljx
@@ -1,6 +1,11 @@
-(ns pathetic.core
-  (:refer-clojure :exclude [resolve])
-  (:require [clojure.string :as str]))
+^:clj (ns pathetic.core
+        (:refer-clojure :exclude [resolve])
+        (:require [clojure.string :as str]))
+
+^:cljs (ns pathetic.core
+         (:refer-clojure :exclude [resolve])
+         (:require [clojure.string :as str]
+                   [goog.string :as string]))
 
 (def ^{:private true} separator "/")
 (def ^{:private true} separator-pattern (re-pattern separator))
@@ -198,11 +203,19 @@
   (render-path (resolve* (parse-path base-path)
                          (parse-path other-path))))
 
+(defn ^:clj ends-with
+  [^String s suffix]
+  (.endsWith s suffix))
+
+(defn ^:cljs ends-with
+  [s suffix]
+  (goog.string.endsWith s suffix))
+
 (defn ensure-trailing-separator
   "If the path given does not have a trailing separator, returns a new path
    that has one."
   [path]
-  (if (.endsWith path separator)
+  (if (ends-with path separator)
     path
     (str path separator)))
 

--- a/test/pathetic/test/core.cljx
+++ b/test/pathetic/test/core.cljx
@@ -1,7 +1,13 @@
-(ns pathetic.test.core
-  (:refer-clojure :exclude [resolve])
-  (:use pathetic.core
-        clojure.test))
+^:clj (ns pathetic.test.core
+        (:refer-clojure :exclude [resolve])
+        (:use pathetic.core
+              clojure.test))
+
+^:cljs (ns pathetic.test.core
+         (:refer-clojure :exclude [resolve])
+         (:require-macros [cemerick.cljs.test :refer (is deftest with-test run-tests testing)])
+         (:use [pathetic.core :only [parse-path render-path up-dir normalize url-normalize relativize resolve split-url-on-path ensure-trailing-separator]])
+         (:require [cemerick.cljs.test :as t]))
 
 (deftest test-parse-path
   (is (= nil (parse-path nil)))


### PR DESCRIPTION
As part of my work to make [url](https://github.com/cemerick/url) ClojureScript compliant I have to add ClojureScript support to pathetic.
As pathetic is almost pure clojure (besides a Java Exception access) this is straightforward.

Still, there are 2 options:
- duplicating the whole clj file into a cljs file (no other change)
- use an external lein plugin (like [cljx](https://github.com/lynaghk/cljx): implies changing source code and project file)

What do you think?
